### PR TITLE
fix: change type hint to generic types supporting python < 3.9? #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Editors
 .vscode/
 .idea/
+*.iml
 
 # Mac/OSX
 .DS_Store


### PR DESCRIPTION
Refs: https://github.com/IBM/hod-archive-sdk-python/issues/1